### PR TITLE
Update Port integration configuration mapping in documentation

### DIFF
--- a/argocd.md
+++ b/argocd.md
@@ -452,6 +452,7 @@ Port integrations use a [YAML mapping block](/build-your-software-catalog/custom
 The mapping makes use of the [JQ JSON processor](https://stedolan.github.io/jq/manual/) to select, modify, concatenate, transform and perform other operations on existing fields and values from the integration API.
 
 ### Default mapping configuration
+<!-- Last updated: b7dd9a9e5e6c443c7311cbb435db7e1fed9451c3-1747498532 -->
 This is the default mapping configuration for the ArgoCD integration.
 
 ```yaml showLineNumber

--- a/pagerduty.md
+++ b/pagerduty.md
@@ -405,6 +405,7 @@ Port integrations use a [YAML mapping block](/build-your-software-catalog/custom
 The mapping makes use of the [JQ JSON processor](https://stedolan.github.io/jq/manual/) to select, modify, concatenate, transform and perform other operations on existing fields and values from the integration API.
 
 ### Default mapping configuration
+<!-- Last updated: b7dd9a9e5e6c443c7311cbb435db7e1fed9451c3-1747498532 -->
 This is the default mapping configuration for the PagerDuty integration.
 
 ```yaml showLineNumber


### PR DESCRIPTION
This PR updates the Port integration configuration mapping sections in documentation files based on changes in the source TypeScript files.

Updated files:
resources/argocd.ts,resources/pagerduty.ts

Automated PR created by GitHub Actions.